### PR TITLE
Build ANTs binaries via GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/build-ants.yml
+++ b/.github/workflows/build-ants.yml
@@ -1,8 +1,6 @@
 name: Build ANTs
 
 on:
-  push:
-    branches: [ master, matrix-build ]
   pull_request:
     branches: [ master ]
   workflow_dispatch:


### PR DESCRIPTION
The goal of this PR is to automate how we build the ANTs binaries used by SCT.

This PR builds off of the work done in https://github.com/kousu/ANTs/pull/5. _(**Context:** That repository starts with a full fork of [ANTsX/ANTs](https://github.com/ANTsX/ANTs), then builds ANTs based on the current state of the fork. While this is helpful for reproducibility, it creates some awkwardness as far as git goes, because it intermingles SCT's build scrips with the existing workflow files from the ANTsX/ANTs repo.)_

So, my plan here is to _not_ fork ANTsX/ANTs entirely, and instead just checkout the repo directly from ANTsX/ANTs,